### PR TITLE
fix: Add support for GlobalCupertinoLocalizations

### DIFF
--- a/src/very_good_flame_game/lib/app/view/app.dart
+++ b/src/very_good_flame_game/lib/app/view/app.dart
@@ -2,7 +2,6 @@ import 'package:audioplayers/audioplayers.dart';
 import 'package:flame/cache.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:very_good_flame_game/l10n/l10n.dart';
 import 'package:very_good_flame_game/loading/loading.dart';
@@ -47,10 +46,7 @@ class AppView extends StatelessWidget {
         ),
         textTheme: GoogleFonts.poppinsTextTheme(),
       ),
-      localizationsDelegates: const [
-        AppLocalizations.delegate,
-        GlobalMaterialLocalizations.delegate,
-      ],
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: const LoadingPage(),
     );

--- a/src/very_good_flame_game/test/helpers/pump_app.dart
+++ b/src/very_good_flame_game/test/helpers/pump_app.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockingjay/mockingjay.dart';
 import 'package:very_good_flame_game/game/cubit/cubit.dart';
@@ -22,10 +21,7 @@ extension PumpApp on WidgetTester {
           BlocProvider.value(value: preloadCubit ?? MockPreloadCubit()),
         ],
         child: MaterialApp(
-          localizationsDelegates: const [
-            AppLocalizations.delegate,
-            GlobalMaterialLocalizations.delegate,
-          ],
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           home: navigator != null
               ? MockNavigatorProvider(navigator: navigator, child: widget)


### PR DESCRIPTION
## Description

Same as with the issue opened in very_good_core [recently](https://github.com/VeryGoodOpenSource/very_good_core/issues/192), I added the `AppLocalizations.localizationsDelegates` to the `localizationsDelegates` of the AppView and in pumpApp helper

This time I ran `dart run tool/generator/main.dart` only locally and didn't committed the changes into vcs, cause I saw @felangel reverted them

Thanks!

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
