### PR TITLE
fix: text style tests for `CounterComponent`

### DIFF
--- a/src/very_good_flame_game/lib/game/components/counter_component.dart
+++ b/src/very_good_flame_game/lib/game/components/counter_component.dart
@@ -1,6 +1,4 @@
 import 'package:flame/components.dart';
-import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:very_good_flame_game/game/game.dart';
 
 class CounterComponent extends PositionComponent
@@ -17,10 +15,7 @@ class CounterComponent extends PositionComponent
       text = TextComponent(
         anchor: Anchor.center,
         textRenderer: TextPaint(
-          style: GoogleFonts.poppins(
-            color: Colors.white,
-            fontSize: 4,
-          ),
+          style: game.textStyle,
         ),
       ),
     );

--- a/src/very_good_flame_game/lib/game/very_good_flame_game.dart
+++ b/src/very_good_flame_game/lib/game/very_good_flame_game.dart
@@ -1,9 +1,7 @@
-import 'dart:ui';
-
 import 'package:audioplayers/audioplayers.dart';
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
-import 'package:flame/palette.dart';
+import 'package:flutter/painting.dart';
 import 'package:very_good_flame_game/game/game.dart';
 import 'package:very_good_flame_game/l10n/l10n.dart';
 
@@ -11,6 +9,7 @@ class VeryGoodFlameGame extends FlameGame {
   VeryGoodFlameGame({
     required this.l10n,
     required this.effectPlayer,
+    required this.textStyle,
   }) {
     images.prefix = '';
   }
@@ -18,6 +17,8 @@ class VeryGoodFlameGame extends FlameGame {
   final AppLocalizations l10n;
 
   final AudioPlayer effectPlayer;
+
+  final TextStyle textStyle;
 
   int counter = 0;
 

--- a/src/very_good_flame_game/lib/game/view/game_page.dart
+++ b/src/very_good_flame_game/lib/game/view/game_page.dart
@@ -33,6 +33,7 @@ class GameView extends StatefulWidget {
   const GameView({super.key, this.game});
 
   final FlameGame? game;
+
   @override
   State<GameView> createState() => _GameViewState();
 }
@@ -57,10 +58,16 @@ class _GameViewState extends State<GameView> {
 
   @override
   Widget build(BuildContext context) {
+    final textStyle = Theme.of(context).textTheme.bodySmall!.copyWith(
+          color: Colors.white,
+          fontSize: 4,
+        );
+
     _game ??= widget.game ??
         VeryGoodFlameGame(
           l10n: context.l10n,
           effectPlayer: context.read<AudioCubit>().effectPlayer,
+          textStyle: textStyle,
         );
     return Stack(
       children: [

--- a/src/very_good_flame_game/test/game/components/counter_component_test.dart
+++ b/src/very_good_flame_game/test/game/components/counter_component_test.dart
@@ -1,12 +1,9 @@
 // ignore_for_file: cascade_invocations
 
-import 'dart:io';
-
 import 'package:audioplayers/audioplayers.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:very_good_flame_game/game/game.dart';

--- a/src/very_good_flame_game/test/game/components/counter_component_test.dart
+++ b/src/very_good_flame_game/test/game/components/counter_component_test.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:audioplayers/audioplayers.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame_test/flame_test.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -16,35 +17,27 @@ class _MockAppLocalizations extends Mock implements AppLocalizations {}
 class _MockAudioPlayer extends Mock implements AudioPlayer {}
 
 class _VeryGoodFlameGame extends VeryGoodFlameGame {
-  _VeryGoodFlameGame({required super.l10n, required super.effectPlayer});
+  _VeryGoodFlameGame({
+    required super.l10n,
+    required super.effectPlayer,
+    required super.textStyle,
+  });
 
   @override
   Future<void> onLoad() async {}
 }
 
 void main() {
-  TestWidgetsFlutterBinding.ensureInitialized();
-  // https://github.com/material-foundation/flutter-packages/issues/286#issuecomment-1406343761
-  HttpOverrides.global = null;
-
-  setUpAll(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(
-      const MethodChannel('plugins.flutter.io/path_provider'),
-      (message) async => switch (message.method) {
-        ('getTemporaryDirectory' || 'getApplicationSupportDirectory') =>
-          Directory.systemTemp.createTempSync('fake').path,
-        _ => null,
-      },
-    );
-  });
-
   final l10n = _MockAppLocalizations();
   _VeryGoodFlameGame createFlameGame() {
-    return _VeryGoodFlameGame(l10n: l10n, effectPlayer: _MockAudioPlayer());
+    return _VeryGoodFlameGame(
+      l10n: l10n,
+      effectPlayer: _MockAudioPlayer(),
+      textStyle: const TextStyle(),
+    );
   }
 
-  group('CounterComponent', () {
+  group('$CounterComponent', () {
     setUp(() {
       when(() => l10n.counterText(any())).thenAnswer(
         (invocation) => 'counterText: ${invocation.positionalArguments[0]}',

--- a/src/very_good_flame_game/test/game/entities/unicorn/behaviors/tapping_behavior_test.dart
+++ b/src/very_good_flame_game/test/game/entities/unicorn/behaviors/tapping_behavior_test.dart
@@ -4,6 +4,7 @@ import 'package:audioplayers/audioplayers.dart';
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:flame_test/flame_test.dart';
+import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:very_good_flame_game/game/entities/unicorn/behaviors/behaviors.dart';
@@ -17,7 +18,11 @@ class _MockAppLocalizations extends Mock implements AppLocalizations {}
 class _MockAudioPlayer extends Mock implements AudioPlayer {}
 
 class _VeryGoodFlameGame extends VeryGoodFlameGame {
-  _VeryGoodFlameGame({required super.l10n, required super.effectPlayer});
+  _VeryGoodFlameGame({
+    required super.l10n,
+    required super.effectPlayer,
+    required super.textStyle,
+  });
 
   @override
   Future<void> onLoad() async {}
@@ -29,7 +34,11 @@ void main() {
   final l10n = _MockAppLocalizations();
   final audioPlayer = _MockAudioPlayer();
   final flameTester = FlameTester(
-    () => _VeryGoodFlameGame(l10n: l10n, effectPlayer: audioPlayer),
+    () => _VeryGoodFlameGame(
+      l10n: l10n,
+      effectPlayer: audioPlayer,
+      textStyle: const TextStyle(),
+    ),
   );
 
   group('TappingBehavior', () {

--- a/src/very_good_flame_game/test/game/entities/unicorn/unicorn_test.dart
+++ b/src/very_good_flame_game/test/game/entities/unicorn/unicorn_test.dart
@@ -3,6 +3,7 @@
 import 'package:audioplayers/audioplayers.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame_test/flame_test.dart';
+import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:very_good_flame_game/game/entities/unicorn/behaviors/behaviors.dart';
@@ -14,7 +15,11 @@ class _MockAppLocalizations extends Mock implements AppLocalizations {}
 class _MockAudioPlayer extends Mock implements AudioPlayer {}
 
 class _VeryGoodFlameGame extends VeryGoodFlameGame {
-  _VeryGoodFlameGame({required super.l10n, required super.effectPlayer});
+  _VeryGoodFlameGame({
+    required super.l10n,
+    required super.effectPlayer,
+    required super.textStyle,
+  });
 
   @override
   Future<void> onLoad() async {}
@@ -25,7 +30,11 @@ void main() {
 
   final l10n = _MockAppLocalizations();
   _VeryGoodFlameGame createFlameGame() {
-    return _VeryGoodFlameGame(l10n: l10n, effectPlayer: _MockAudioPlayer());
+    return _VeryGoodFlameGame(
+      l10n: l10n,
+      effectPlayer: _MockAudioPlayer(),
+      textStyle: const TextStyle(),
+    );
   }
 
   group('Unicorn', () {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description



Inject text style from the theme instead of getting it directly from  `google_fonts`. The reason is that the newer version of `google_fonts` kept breaking unit tests, forcing us to do some mocking. 

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
