### PR TITLE
fix: resolve image caching issue on flame_game template

### DIFF
--- a/src/very_good_flame_game/lib/game/entities/unicorn/unicorn.dart
+++ b/src/very_good_flame_game/lib/game/entities/unicorn/unicorn.dart
@@ -30,8 +30,8 @@ class Unicorn extends PositionedEntity with HasGameRef {
 
   @override
   Future<void> onLoad() async {
-    final animation = await gameRef.loadSpriteAnimation(
-      Assets.images.unicornAnimation.path,
+    final animation = SpriteAnimation.fromFrameData(
+      gameRef.images.fromCache(Assets.images.unicornAnimation.path),
       SpriteAnimationData.sequenced(
         amount: 16,
         stepTime: 0.1,

--- a/src/very_good_flame_game/lib/game/very_good_flame_game.dart
+++ b/src/very_good_flame_game/lib/game/very_good_flame_game.dart
@@ -1,4 +1,5 @@
 import 'package:audioplayers/audioplayers.dart';
+import 'package:flame/cache.dart';
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:flutter/painting.dart';
@@ -10,8 +11,9 @@ class VeryGoodFlameGame extends FlameGame {
     required this.l10n,
     required this.effectPlayer,
     required this.textStyle,
+    required Images images,
   }) {
-    images.prefix = '';
+    this.images = images;
   }
 
   final AppLocalizations l10n;

--- a/src/very_good_flame_game/lib/game/view/game_page.dart
+++ b/src/very_good_flame_game/lib/game/view/game_page.dart
@@ -68,6 +68,7 @@ class _GameViewState extends State<GameView> {
           l10n: context.l10n,
           effectPlayer: context.read<AudioCubit>().effectPlayer,
           textStyle: textStyle,
+          images: context.read<PreloadCubit>().images,
         );
     return Stack(
       children: [

--- a/src/very_good_flame_game/test/game/components/counter_component_test.dart
+++ b/src/very_good_flame_game/test/game/components/counter_component_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: cascade_invocations
 
 import 'package:audioplayers/audioplayers.dart';
+import 'package:flame/cache.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter/material.dart';
@@ -18,6 +19,7 @@ class _VeryGoodFlameGame extends VeryGoodFlameGame {
     required super.l10n,
     required super.effectPlayer,
     required super.textStyle,
+    required super.images,
   });
 
   @override
@@ -25,22 +27,26 @@ class _VeryGoodFlameGame extends VeryGoodFlameGame {
 }
 
 void main() {
-  final l10n = _MockAppLocalizations();
-  _VeryGoodFlameGame createFlameGame() {
+  late final AppLocalizations l10n;
+
+  setUpAll(() {
+    l10n = _MockAppLocalizations();
+
+    when(() => l10n.counterText(any())).thenAnswer(
+      (invocation) => 'counterText: ${invocation.positionalArguments[0]}',
+    );
+  });
+
+  VeryGoodFlameGame createFlameGame() {
     return _VeryGoodFlameGame(
       l10n: l10n,
       effectPlayer: _MockAudioPlayer(),
       textStyle: const TextStyle(),
+      images: Images(),
     );
   }
 
   group('$CounterComponent', () {
-    setUp(() {
-      when(() => l10n.counterText(any())).thenAnswer(
-        (invocation) => 'counterText: ${invocation.positionalArguments[0]}',
-      );
-    });
-
     testWithGame(
       'has all components',
       createFlameGame,

--- a/src/very_good_flame_game/test/game/components/counter_component_test.dart
+++ b/src/very_good_flame_game/test/game/components/counter_component_test.dart
@@ -27,26 +27,26 @@ class _VeryGoodFlameGame extends VeryGoodFlameGame {
 }
 
 void main() {
-  late final AppLocalizations l10n;
-
-  setUpAll(() {
-    l10n = _MockAppLocalizations();
-
-    when(() => l10n.counterText(any())).thenAnswer(
-      (invocation) => 'counterText: ${invocation.positionalArguments[0]}',
-    );
-  });
-
-  VeryGoodFlameGame createFlameGame() {
-    return _VeryGoodFlameGame(
-      l10n: l10n,
-      effectPlayer: _MockAudioPlayer(),
-      textStyle: const TextStyle(),
-      images: Images(),
-    );
-  }
-
   group('$CounterComponent', () {
+    late AppLocalizations l10n;
+
+    setUp(() {
+      l10n = _MockAppLocalizations();
+
+      when(() => l10n.counterText(any())).thenAnswer(
+        (invocation) => 'counterText: ${invocation.positionalArguments[0]}',
+      );
+    });
+
+    VeryGoodFlameGame createFlameGame() {
+      return _VeryGoodFlameGame(
+        l10n: l10n,
+        effectPlayer: _MockAudioPlayer(),
+        textStyle: const TextStyle(),
+        images: Images(),
+      );
+    }
+
     testWithGame(
       'has all components',
       createFlameGame,

--- a/src/very_good_flame_game/test/game/entities/unicorn/behaviors/tapping_behavior_test.dart
+++ b/src/very_good_flame_game/test/game/entities/unicorn/behaviors/tapping_behavior_test.dart
@@ -1,7 +1,9 @@
 // ignore_for_file: cascade_invocations
 
+import 'dart:ui';
+
 import 'package:audioplayers/audioplayers.dart';
-import 'package:flame/components.dart';
+import 'package:flame/cache.dart';
 import 'package:flame/game.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter/painting.dart';
@@ -13,6 +15,8 @@ import 'package:very_good_flame_game/l10n/l10n.dart';
 
 class _FakeAssetSource extends Fake implements AssetSource {}
 
+class _MockImages extends Mock implements Images {}
+
 class _MockAppLocalizations extends Mock implements AppLocalizations {}
 
 class _MockAudioPlayer extends Mock implements AudioPlayer {}
@@ -22,6 +26,7 @@ class _VeryGoodFlameGame extends VeryGoodFlameGame {
     required super.l10n,
     required super.effectPlayer,
     required super.textStyle,
+    required super.images,
   });
 
   @override
@@ -33,23 +38,38 @@ void main() {
 
   final l10n = _MockAppLocalizations();
   final audioPlayer = _MockAudioPlayer();
+  final images = _MockImages();
   final flameTester = FlameTester(
     () => _VeryGoodFlameGame(
       l10n: l10n,
       effectPlayer: audioPlayer,
       textStyle: const TextStyle(),
+      images: images,
     ),
   );
 
+  Future<Image> fakeImage() async {
+    final recorder = PictureRecorder();
+    final canvas = Canvas(recorder);
+    canvas.drawRect(
+      const Rect.fromLTWH(0, 0, 1, 1),
+      Paint()..color = const Color(0xFF000000),
+    );
+    final picture = recorder.endRecording();
+    return picture.toImage(1, 1);
+  }
+
   group('TappingBehavior', () {
-    setUpAll(() {
+    late final Image image;
+
+    setUpAll(() async {
       registerFallbackValue(_FakeAssetSource());
-    });
 
-    setUp(() {
+      image = await fakeImage();
+
       when(() => l10n.counterText(any())).thenReturn('counterText');
-
       when(() => audioPlayer.play(any())).thenAnswer((_) async {});
+      when(() => images.fromCache(any())).thenReturn(image);
     });
 
     flameTester.testGameWidget(

--- a/src/very_good_flame_game/test/game/entities/unicorn/behaviors/tapping_behavior_test.dart
+++ b/src/very_good_flame_game/test/game/entities/unicorn/behaviors/tapping_behavior_test.dart
@@ -54,17 +54,6 @@ void main() {
       registerFallbackValue(_FakeAssetSource());
     });
 
-    Future<Image> fakeImage() async {
-      final recorder = PictureRecorder();
-      final canvas = Canvas(recorder);
-      canvas.drawRect(
-        const Rect.fromLTWH(0, 0, 1, 1),
-        Paint()..color = const Color(0xFF000000),
-      );
-      final picture = recorder.endRecording();
-      return picture.toImage(1, 1);
-    }
-
     setUp(() async {
       l10n = _MockAppLocalizations();
       when(() => l10n.counterText(any())).thenReturn('counterText');
@@ -73,7 +62,7 @@ void main() {
       when(() => audioPlayer.play(any())).thenAnswer((_) async {});
 
       images = _MockImages();
-      final image = await fakeImage();
+      final image = await _fakeImage();
       when(() => images.fromCache(any())).thenReturn(image);
     });
 
@@ -105,4 +94,15 @@ void main() {
       },
     );
   });
+}
+
+Future<Image> _fakeImage() async {
+  final recorder = PictureRecorder();
+  final canvas = Canvas(recorder);
+  canvas.drawRect(
+    const Rect.fromLTWH(0, 0, 1, 1),
+    Paint()..color = const Color(0xFF000000),
+  );
+  final picture = recorder.endRecording();
+  return picture.toImage(1, 1);
 }

--- a/src/very_good_flame_game/test/game/entities/unicorn/behaviors/tapping_behavior_test.dart
+++ b/src/very_good_flame_game/test/game/entities/unicorn/behaviors/tapping_behavior_test.dart
@@ -36,43 +36,50 @@ class _VeryGoodFlameGame extends VeryGoodFlameGame {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  final l10n = _MockAppLocalizations();
-  final audioPlayer = _MockAudioPlayer();
-  final images = _MockImages();
-  final flameTester = FlameTester(
-    () => _VeryGoodFlameGame(
-      l10n: l10n,
-      effectPlayer: audioPlayer,
-      textStyle: const TextStyle(),
-      images: images,
-    ),
-  );
-
-  Future<Image> fakeImage() async {
-    final recorder = PictureRecorder();
-    final canvas = Canvas(recorder);
-    canvas.drawRect(
-      const Rect.fromLTWH(0, 0, 1, 1),
-      Paint()..color = const Color(0xFF000000),
-    );
-    final picture = recorder.endRecording();
-    return picture.toImage(1, 1);
-  }
-
   group('TappingBehavior', () {
-    late final Image image;
+    late AppLocalizations l10n;
+    late AudioPlayer audioPlayer;
+    late Images images;
+
+    FlameTester createFlameGameTester() {
+      return FlameTester(
+        () => _VeryGoodFlameGame(
+          l10n: l10n,
+          effectPlayer: audioPlayer,
+          textStyle: const TextStyle(),
+          images: images,
+        ),
+      );
+    }
 
     setUpAll(() async {
       registerFallbackValue(_FakeAssetSource());
+    });
 
-      image = await fakeImage();
+    Future<Image> fakeImage() async {
+      final recorder = PictureRecorder();
+      final canvas = Canvas(recorder);
+      canvas.drawRect(
+        const Rect.fromLTWH(0, 0, 1, 1),
+        Paint()..color = const Color(0xFF000000),
+      );
+      final picture = recorder.endRecording();
+      return picture.toImage(1, 1);
+    }
 
+    setUp(() async {
+      l10n = _MockAppLocalizations();
       when(() => l10n.counterText(any())).thenReturn('counterText');
+
+      audioPlayer = _MockAudioPlayer();
       when(() => audioPlayer.play(any())).thenAnswer((_) async {});
+
+      images = _MockImages();
+      final image = await fakeImage();
       when(() => images.fromCache(any())).thenReturn(image);
     });
 
-    flameTester.testGameWidget(
+    createFlameGameTester().testGameWidget(
       'when tapped, starts playing the animation',
       setUp: (game, tester) async {
         await game.ensureAdd(

--- a/src/very_good_flame_game/test/game/entities/unicorn/behaviors/tapping_behavior_test.dart
+++ b/src/very_good_flame_game/test/game/entities/unicorn/behaviors/tapping_behavior_test.dart
@@ -41,14 +41,12 @@ void main() {
     late AudioPlayer audioPlayer;
     late Images images;
 
-    FlameTester createFlameGameTester() {
-      return FlameTester(
-        () => _VeryGoodFlameGame(
-          l10n: l10n,
-          effectPlayer: audioPlayer,
-          textStyle: const TextStyle(),
-          images: images,
-        ),
+    VeryGoodFlameGame createFlameGame() {
+      return _VeryGoodFlameGame(
+        l10n: l10n,
+        effectPlayer: audioPlayer,
+        textStyle: const TextStyle(),
+        images: images,
       );
     }
 
@@ -79,7 +77,7 @@ void main() {
       when(() => images.fromCache(any())).thenReturn(image);
     });
 
-    createFlameGameTester().testGameWidget(
+    FlameTester(createFlameGame).testGameWidget(
       'when tapped, starts playing the animation',
       setUp: (game, tester) async {
         await game.ensureAdd(

--- a/src/very_good_flame_game/test/game/entities/unicorn/unicorn_test.dart
+++ b/src/very_good_flame_game/test/game/entities/unicorn/unicorn_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: cascade_invocations
 
 import 'package:audioplayers/audioplayers.dart';
+import 'package:flame/cache.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter/painting.dart';
@@ -10,15 +11,20 @@ import 'package:very_good_flame_game/game/entities/unicorn/behaviors/behaviors.d
 import 'package:very_good_flame_game/game/game.dart';
 import 'package:very_good_flame_game/l10n/l10n.dart';
 
+class _FakeImage extends Fake implements Image {}
+
 class _MockAppLocalizations extends Mock implements AppLocalizations {}
 
 class _MockAudioPlayer extends Mock implements AudioPlayer {}
+
+class _MockImages extends Mock implements Images {}
 
 class _VeryGoodFlameGame extends VeryGoodFlameGame {
   _VeryGoodFlameGame({
     required super.l10n,
     required super.effectPlayer,
     required super.textStyle,
+    required super.images,
   });
 
   @override
@@ -28,20 +34,27 @@ class _VeryGoodFlameGame extends VeryGoodFlameGame {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  final l10n = _MockAppLocalizations();
+  late final AppLocalizations l10n;
+  late final Images images;
+
+  setUpAll(() {
+    l10n = _MockAppLocalizations();
+    images = _MockImages();
+
+    when(() => l10n.counterText(any())).thenReturn('counterText');
+    when(() => images.fromCache(any())).thenReturn(_FakeImage());
+  });
+
   _VeryGoodFlameGame createFlameGame() {
     return _VeryGoodFlameGame(
       l10n: l10n,
       effectPlayer: _MockAudioPlayer(),
       textStyle: const TextStyle(),
+      images: images,
     );
   }
 
   group('Unicorn', () {
-    setUp(() {
-      when(() => l10n.counterText(any())).thenReturn('counterText');
-    });
-
     testWithGame(
       'has all behaviors',
       createFlameGame,

--- a/src/very_good_flame_game/test/game/entities/unicorn/unicorn_test.dart
+++ b/src/very_good_flame_game/test/game/entities/unicorn/unicorn_test.dart
@@ -34,27 +34,27 @@ class _VeryGoodFlameGame extends VeryGoodFlameGame {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  late final AppLocalizations l10n;
-  late final Images images;
-
-  setUpAll(() {
-    l10n = _MockAppLocalizations();
-    images = _MockImages();
-
-    when(() => l10n.counterText(any())).thenReturn('counterText');
-    when(() => images.fromCache(any())).thenReturn(_FakeImage());
-  });
-
-  _VeryGoodFlameGame createFlameGame() {
-    return _VeryGoodFlameGame(
-      l10n: l10n,
-      effectPlayer: _MockAudioPlayer(),
-      textStyle: const TextStyle(),
-      images: images,
-    );
-  }
-
   group('Unicorn', () {
+    late AppLocalizations l10n;
+    late Images images;
+
+    setUp(() {
+      l10n = _MockAppLocalizations();
+      images = _MockImages();
+
+      when(() => l10n.counterText(any())).thenReturn('counterText');
+      when(() => images.fromCache(any())).thenReturn(_FakeImage());
+    });
+
+    _VeryGoodFlameGame createFlameGame() {
+      return _VeryGoodFlameGame(
+        l10n: l10n,
+        effectPlayer: _MockAudioPlayer(),
+        textStyle: const TextStyle(),
+        images: images,
+      );
+    }
+
     testWithGame(
       'has all behaviors',
       createFlameGame,

--- a/src/very_good_flame_game/test/game/view/game_page_test.dart
+++ b/src/very_good_flame_game/test/game/view/game_page_test.dart
@@ -30,6 +30,9 @@ class _MockImages extends Mock implements Images {}
 
 class _MockBgm extends Mock implements Bgm {}
 
+class _MockPreloadCubit extends MockCubit<PreloadState>
+    implements PreloadCubit {}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   // https://github.com/material-foundation/flutter-packages/issues/286#issuecomment-1406343761
@@ -58,7 +61,7 @@ void main() {
     late final Images images;
 
     setUpAll(() {
-      preloadCubit = MockPreloadCubit();
+      preloadCubit = _MockPreloadCubit();
       images = _MockImages();
 
       when(() => preloadCubit.audio).thenReturn(AudioCache(prefix: ''));

--- a/src/very_good_flame_game/test/game/view/game_page_test.dart
+++ b/src/very_good_flame_game/test/game/view/game_page_test.dart
@@ -2,9 +2,11 @@
 
 import 'dart:async';
 import 'dart:io';
+import 'dart:ui' as ui;
 
 import 'package:audioplayers/audioplayers.dart';
 import 'package:bloc_test/bloc_test.dart';
+import 'package:flame/cache.dart';
 import 'package:flame_audio/bgm.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -18,9 +20,13 @@ import '../../helpers/helpers.dart';
 
 class _FakeAssetSource extends Fake implements AssetSource {}
 
+class _FakeImage extends Fake implements ui.Image {}
+
 class _MockAudioCubit extends MockCubit<AudioState> implements AudioCubit {}
 
 class _MockAudioPlayer extends Mock implements AudioPlayer {}
+
+class _MockImages extends Mock implements Images {}
 
 class _MockBgm extends Mock implements Bgm {}
 
@@ -48,14 +54,17 @@ void main() {
   });
 
   group('GamePage', () {
-    late PreloadCubit preloadCubit;
-
-    setUp(() {
-      preloadCubit = MockPreloadCubit();
-      when(() => preloadCubit.audio).thenReturn(AudioCache(prefix: ''));
-    });
+    late final PreloadCubit preloadCubit;
+    late final Images images;
 
     setUpAll(() {
+      preloadCubit = MockPreloadCubit();
+      images = _MockImages();
+
+      when(() => preloadCubit.audio).thenReturn(AudioCache(prefix: ''));
+      when(() => preloadCubit.images).thenReturn(images);
+      when(() => images.fromCache(any())).thenReturn(_FakeImage());
+
       registerFallbackValue(_FakeAssetSource());
     });
 

--- a/src/very_good_flame_game/test/game/view/game_page_test.dart
+++ b/src/very_good_flame_game/test/game/view/game_page_test.dart
@@ -65,12 +65,12 @@ void main() {
     });
 
     setUp(() {
-      preloadCubit = _MockPreloadCubit();
       images = _MockImages();
+      when(() => images.fromCache(any())).thenReturn(_FakeImage());
 
+      preloadCubit = _MockPreloadCubit();
       when(() => preloadCubit.audio).thenReturn(AudioCache(prefix: ''));
       when(() => preloadCubit.images).thenReturn(images);
-      when(() => images.fromCache(any())).thenReturn(_FakeImage());
     });
 
     testWidgets('is routable', (tester) async {

--- a/src/very_good_flame_game/test/game/view/game_page_test.dart
+++ b/src/very_good_flame_game/test/game/view/game_page_test.dart
@@ -57,18 +57,20 @@ void main() {
   });
 
   group('GamePage', () {
-    late final PreloadCubit preloadCubit;
-    late final Images images;
+    late PreloadCubit preloadCubit;
+    late Images images;
 
     setUpAll(() {
+      registerFallbackValue(_FakeAssetSource());
+    });
+
+    setUp(() {
       preloadCubit = _MockPreloadCubit();
       images = _MockImages();
 
       when(() => preloadCubit.audio).thenReturn(AudioCache(prefix: ''));
       when(() => preloadCubit.images).thenReturn(images);
       when(() => images.fromCache(any())).thenReturn(_FakeImage());
-
-      registerFallbackValue(_FakeAssetSource());
     });
 
     testWidgets('is routable', (tester) async {


### PR DESCRIPTION
## Status

**READY**

## Description

Fixes: https://github.com/VeryGoodOpenSource/very_good_cli/issues/918

There is a bug on the generated flame_game template. The cached images are not accessible from the FlameGame, therefore they are not "actually" cached and causing a runtime error. This pull request fixes the issue.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
